### PR TITLE
add mechanism for outgoing MIDI notes

### DIFF
--- a/bistro.lua
+++ b/bistro.lua
@@ -62,8 +62,7 @@ function init()
   params:add_separator()
   hs.init()
   
-  midi_lib.init("out")
-  midi_out.active_notes = {}
+  midi_lib.init()
   
   params:bang()
   
@@ -123,7 +122,6 @@ function tick()
           engine.hz(freq)
           
           track.active_note = note
-          midi_out:note_off(track.active_note, params:get("MIDI_out_velocity"), params:get("MIDI_out_channel"))
           midi_out:note_on(track.active_note, params:get("MIDI_out_velocity"), params:get("MIDI_out_channel"))
           
         else

--- a/bistro.lua
+++ b/bistro.lua
@@ -8,6 +8,7 @@ engine.name = "KarplusRings"
 local MusicUtil = require "musicutil"
 local rings = include("we/lib/karplus_rings")
 local hs = include("lib/halfsecond")
+local midi_lib = include("lib/midi_lib")
 
 local g
 local clk
@@ -32,7 +33,7 @@ function init()
     local note_name = "note_" .. i
     
     params:add_number(note_name, note_name:gsub("_", " "), -24, 24, start_notes[i])
-    tracks[i] = { counter = nil, pattern = nil }
+    tracks[i] = { counter = nil, pattern = nil ,  active_note = nil}
   end
   
   params:add_group("pattern data", g.rows + (g.rows * g.cols))
@@ -42,7 +43,7 @@ function init()
     
     params:add_number(pattern_len_name, pattern_len_name:gsub("_", " "), 1, g.cols, g.cols)
     params:set_action(pattern_len_name, function(x)
-      grid_redraw()
+      grid_dirty = true
     end)
     
     for j=1,g.cols do
@@ -50,7 +51,7 @@ function init()
       
       params:add_number(trig_name, trig_name:gsub("_", " "), 0, 1, math.random() > 0.5 and 1 or 0)
       params:set_action(trig_name, function(x)
-        grid_redraw()
+        grid_dirty = true
       end)
     end
   end
@@ -60,6 +61,9 @@ function init()
   
   params:add_separator()
   hs.init()
+  
+  midi_lib.init("out")
+  midi_out.active_notes = {}
   
   params:bang()
   
@@ -74,8 +78,22 @@ function init()
   params:read()
   
   clk = clock.run(tick)
+  hardware_clk = clock.run(function()
+    while true do
+      clock.sleep(1/30)
+      if grid_dirty then
+        grid_redraw()
+        grid_dirty = false
+      end
+      if screen_dirty then
+        redraw()
+        screen_dirty = false
+      end
+    end
+  end
+  )
   
-  grid_redraw()
+  grid_dirty = true
 end
 
 function cleanup()
@@ -87,8 +105,9 @@ function tick()
     local rate = params:get("clock_rate")
     clock.sync(1/rate)
     
-    grid_redraw()
-    redraw()
+    grid_dirty = true
+    
+    screen_dirty = true
     
     for i=1,g.cols do
       local track = tracks[i]
@@ -102,6 +121,13 @@ function tick()
           local freq = MusicUtil.note_num_to_freq(note)
 
           engine.hz(freq)
+          
+          track.active_note = note
+          midi_out:note_off(track.active_note, params:get("MIDI_out_velocity"), params:get("MIDI_out_channel"))
+          midi_out:note_on(track.active_note, params:get("MIDI_out_velocity"), params:get("MIDI_out_channel"))
+          
+        else
+          midi_out:note_off(track.active_note, params:get("MIDI_out_velocity"), params:get("MIDI_out_channel"))
         end
         
         -- Advance counter.
@@ -152,6 +178,7 @@ function grid_key(x, y, z)
     elseif z == 0 then
       tracks[x].pattern = nil
       tracks[x].counter = nil
+      midi_out:note_off(tracks[x].active_note)
     end
   elseif page == 2 then
     -- PATTERNS
@@ -236,8 +263,8 @@ function enc(n, d)
     end
   end
   
-  grid_redraw()
-  redraw()
+  grid_dirty = true
+  screen_dirty = true
 end
 
 function key(n, z)

--- a/lib/midi_lib.lua
+++ b/lib/midi_lib.lua
@@ -2,11 +2,10 @@ local midi_lib = {}
 
 function midi_lib.init()
   midi_out = nil
-  io_prefix = {"MIDI_in", "MIDI_out"} -- we'll set up many parameters which use these two prefixes
     
   params:add_separator("outgoing MIDI") -- separators help keep the PARAMETERS menu UI clean
     
-  midi_out = midi.connect(1) -- connect both midi input and output to vport 1
+  midi_out = midi.connect(1) -- connect midi output to vport 1
     
   params:add_number("MIDI_out_device", "device", 1, #midi.vports, 1) -- vport selector
   params:set_action("MIDI_out_device", function(x) -- when this parameter changes, peform the following:

--- a/lib/midi_lib.lua
+++ b/lib/midi_lib.lua
@@ -13,9 +13,9 @@ function midi_lib.init()
     midi_lib.update_midi_params() -- update the params to match the newly-selected device
   end)
   
-  params:add_text("MIDI_out_name", ">>> device name", midi_out.name) -- display the selected vport's device name
+  params:add_text("MIDI_out_name", ">>> dev. name", string.len(midi_out.name) > 15 and util.acronym(midi_out.name) or midi_out.name) -- display the selected vport's device name
   
-  params:add_text("MIDI_out_state", ">>> device connected", tostring(midi_out.connected)) -- display the selected vport's connected state
+  params:add_text("MIDI_out_state", ">>> dev. connected?", tostring(midi_out.connected)) -- display the selected vport's connected state
   
   params:add_number("MIDI_out_channel", "channel", 1, 16, 1)
   params:add_number("MIDI_out_velocity", "velocity", 0, 127, 100)
@@ -23,7 +23,7 @@ function midi_lib.init()
 end
 
 function midi_lib.update_midi_params() -- updates info-only parameters, to help user identify port/device pairs
-  params:set("MIDI_out_name",midi_out.name)
+  params:set("MIDI_out_name",(string.len(midi_out.name) > 15 and util.acronym(midi_out.name) or midi_out.name))
   params:set("MIDI_out_state",tostring(midi_out.connected))
 end
 

--- a/lib/midi_lib.lua
+++ b/lib/midi_lib.lua
@@ -1,0 +1,44 @@
+local midi_lib = {}
+
+function midi_lib.init()
+  midi_out = nil
+  io_prefix = {"MIDI_in", "MIDI_out"} -- we'll set up many parameters which use these two prefixes
+    
+  params:add_separator("outgoing MIDI") -- separators help keep the PARAMETERS menu UI clean
+    
+  midi_out = midi.connect(1) -- connect both midi input and output to vport 1
+    
+  params:add_number("MIDI_out_device", "device", 1, #midi.vports, 1) -- vport selector
+  params:set_action("MIDI_out_device", function(x) -- when this parameter changes, peform the following:
+    midi_out = midi.connect(x) -- update the script's MIDI input or output device
+    midi_lib.update_midi_params() -- update the params to match the newly-selected device
+  end)
+  
+  params:add_text("MIDI_out_name", ">>> device name", midi_out.name) -- display the selected vport's device name
+  
+  params:add_text("MIDI_out_state", ">>> device connected", tostring(midi_out.connected)) -- display the selected vport's connected state
+  
+  params:add_number("MIDI_out_channel", "channel", 1, 16, 1)
+  params:add_number("MIDI_out_velocity", "velocity", 0, 127, 100)
+  
+end
+
+function midi_lib.update_midi_params() -- updates info-only parameters, to help user identify port/device pairs
+  params:set("MIDI_out_name",midi_out.name)
+  params:set("MIDI_out_state",tostring(midi_out.connected))
+end
+
+function midi.add() -- this gets called when a MIDI device is registered
+  midi_lib.update_midi_params() -- update params
+end
+
+function midi.remove() -- this gets called when a MIDI device is removed
+  clock.run(
+    function()
+      clock.sleep(0.25) -- wait a 1/4 second for the device to be released
+        midi_lib.update_midi_params() -- update params
+    end
+  )
+end
+
+return midi_lib


### PR DESCRIPTION
hey hey! :)

- lib/midi_lib adds parameters for outgoing MIDI (device, channel, velocity)
- tracks[i] now has an `active_note` entry
- midi note is triggered on each track when pattern step is 1, not off is triggered when step is 0
- midi note off is triggered when grid key is released
- employed a `grid_dirty` mechanism to avoid libmonome flooding at script start

hope this helps! lmk if anything looks wonky / unclear!