### PR TITLE
direct to new location for karplus_rings

### DIFF
--- a/bistro.lua
+++ b/bistro.lua
@@ -6,7 +6,7 @@
 engine.name = "KarplusRings"
 
 local MusicUtil = require "musicutil"
-local rings = include("we/lib/karplus_rings")
+local rings = include("awake-rings/lib/karplus_rings")
 local hs = include("lib/halfsecond")
 local midi_lib = include("lib/midi_lib")
 


### PR DESCRIPTION
shwee! from https://llllllll.co/t/bistro/45349/61, `karplus_rings` file now lives in the `awake-rings` repo as `we` has been deprecated. tested well on my side, lmk if i missed anything!