### PR TITLE
Latch and fixed engine parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
 # bistro
 
 "press cafe" remake for Monome Norns.
+
+- E1 choose play, patterns, length page
+
+	On play page <kbd>E2</kbd> cutoff, <kbd>E3</kbd>pw, <kbd>K3</kbd> to latch. On patterns and length pages <kbd>K3</kbd> to randomize patterns.

--- a/README.md
+++ b/README.md
@@ -4,4 +4,7 @@
 
 - E1 choose play, patterns, length page
 
-On play page <kbd>E2</kbd> cutoff, <kbd>E3</kbd>pw, <kbd>K3</kbd> to latch. On patterns and length pages <kbd>K3</kbd> to randomize patterns.
+On play page <kbd>K3</kbd> to latch. <kbd>E2</kbd> damping, <kbd>E3</kbd> brightness, <kbd>K2</kbd>+<kbd>E2</kbd> lowpass frequency and <kbd>K2</kbd>+<kbd>E3</kbd> bandpass frequency.
+
+On patterns and length pages <kbd>K3</kbd> to randomize.
+

--- a/README.md
+++ b/README.md
@@ -4,4 +4,4 @@
 
 - E1 choose play, patterns, length page
 
-	On play page <kbd>E2</kbd> cutoff, <kbd>E3</kbd>pw, <kbd>K3</kbd> to latch. On patterns and length pages <kbd>K3</kbd> to randomize patterns.
+On play page <kbd>E2</kbd> cutoff, <kbd>E3</kbd>pw, <kbd>K3</kbd> to latch. On patterns and length pages <kbd>K3</kbd> to randomize patterns.

--- a/bistro.lua
+++ b/bistro.lua
@@ -324,7 +324,7 @@ function redraw()
     for i=1,g.cols do
       local track = tracks[i]
       
-      screen.move(10 + (i-1)*10, 36)
+      screen.move(i*(128/(g.cols+1)), 36)
       
       if track.pattern ~= nil and track.counter ~= nil then
         local p = get_pattern(track.pattern)

--- a/bistro.lua
+++ b/bistro.lua
@@ -324,7 +324,7 @@ function redraw()
     for i=1,g.cols do
       local track = tracks[i]
       
-      screen.move(i*(128/(g.cols+1)), 36)
+      screen.move(i*(128/(g.cols+1)), 36+latch*4)
       
       if track.pattern ~= nil and track.counter ~= nil then
         local p = get_pattern(track.pattern)

--- a/bistro.lua
+++ b/bistro.lua
@@ -177,10 +177,10 @@ end
 function grid_key(x, y, z)
   if page == 1 then
     -- PLAY
-    if z == 1 and tracks[x].counter == nil then
+    if z == 1 and tracks[x].counter == nil or latch == 1 then
       tracks[x].pattern = y
       tracks[x].counter = 1
-    elseif z == 0 and latch ~= 1 then
+    elseif z == 0 then
       tracks[x].pattern = nil
       tracks[x].counter = nil
       midi_out:note_off(tracks[x].active_note)

--- a/bistro.lua
+++ b/bistro.lua
@@ -2,6 +2,10 @@
 -- "press cafe" remake
 -- by: @cfd90
 -- originally by: @stretta
+--
+-- on play page
+--   E2 cutoff, E3 pw, K3 latch
+-- other pages K3 to randomize
 
 engine.name = "KarplusRings"
 
@@ -12,6 +16,7 @@ local midi_lib = include("lib/midi_lib")
 
 local g
 local clk
+local latch = 0
 
 local pages = {"PLAY", "PATTERNS", "LENGTHS"}
 local page = 1
@@ -22,7 +27,7 @@ function init()
   g = grid.connect()
   g.key = grid_key
   
-  params:add_separator()
+  params:add_separator("sequence")
   params:add_option("clock_rate", "clock rate", {1, 2, 4, 8, 16}, 4)
   params:add_group("note data", 1 + g.cols)
   params:add_number("base_note", "base note", 1, 127, 48)
@@ -54,12 +59,13 @@ function init()
         grid_dirty = true
       end)
     end
+
   end
   
-  params:add_separator()
+  params:add_separator("rings")
   rings.params()
   
-  params:add_separator()
+  params:add_separator("halfsecond")
   hs.init()
   
   midi_lib.init()
@@ -173,7 +179,7 @@ function grid_key(x, y, z)
     if z == 1 and tracks[x].counter == nil then
       tracks[x].pattern = y
       tracks[x].counter = 1
-    elseif z == 0 then
+    elseif z == 0 and latch ~= 1 then
       tracks[x].pattern = nil
       tracks[x].counter = nil
       midi_out:note_off(tracks[x].active_note)
@@ -250,9 +256,9 @@ end
 function enc(n, d)
   if n == 1 then
     page = util.clamp(page + d, 1, #pages)
-    
+
     for i=1,g.cols do
-      tracks[i] = { counter = nil, pattern = nil }
+       tracks[i] = { counter = nil, pattern = nil }
     end
   end
   
@@ -270,14 +276,13 @@ function enc(n, d)
 end
 
 function key(n, z)
-  if z == 0 then
-    return
-  end
-  
   if page == 1 then
     -- PLAY
     -- todo: random notes?
-  elseif page == 2 then
+     if n == 3 then
+	latch = z
+     end
+  elseif page == 2 and z == 1 then
     -- PATTERNS
     if n == 3 then
       for i=1,g.cols do
@@ -286,7 +291,7 @@ function key(n, z)
         end
       end
     end
-  elseif page == 3 then
+  elseif page == 3 and z == 1 then
     -- LENGTH
     if n == 3 then
       for i=1,g.cols do

--- a/bistro.lua
+++ b/bistro.lua
@@ -3,8 +3,8 @@
 -- by: @cfd90
 -- originally by: @stretta
 --
--- on play page
---   E2 cutoff, E3 pw, K3 latch
+-- on play page K3 to latch
+--  E2, E3, K2+E2, K2+E3 voice
 -- other pages K3 to randomize
 
 engine.name = "KarplusRings"
@@ -16,6 +16,7 @@ local midi_lib = include("lib/midi_lib")
 
 local g
 local clk
+local filter_ctrl = 0
 local latch = 0
 
 local pages = {"PLAY", "PATTERNS", "LENGTHS"}
@@ -265,9 +266,17 @@ function enc(n, d)
   if page == 1 then
     -- PLAY
     if n == 2 then
-      params:delta("cutoff", d)
+      if filter_ctrl == 1 then
+         params:delta("lpf_freq", d)
+      else
+	 params:delta("damping", d)
+      end
     elseif n == 3 then
-      params:delta("pw", d)
+      if filter_ctrl == 1 then
+         params:delta("bpf_freq", d)
+      else
+	 params:delta("brightness", d)
+      end
     end
   end
   
@@ -279,7 +288,9 @@ function key(n, z)
   if page == 1 then
     -- PLAY
     -- todo: random notes?
-     if n == 3 then
+     if n == 2 then
+	filter_ctrl = z
+     elseif n == 3 then
 	latch = z
      end
   elseif page == 2 and z == 1 then

--- a/bistro.lua
+++ b/bistro.lua
@@ -27,7 +27,7 @@ function init()
   g = grid.connect()
   g.key = grid_key
   
-  params:add_separator("sequence")
+  params:add_separator("press cafe")
   params:add_option("clock_rate", "clock rate", {1, 2, 4, 8, 16}, 4)
   params:add_group("note data", 1 + g.cols)
   params:add_number("base_note", "base note", 1, 127, 48)
@@ -256,9 +256,9 @@ end
 function enc(n, d)
   if n == 1 then
     page = util.clamp(page + d, 1, #pages)
-
+    
     for i=1,g.cols do
-       tracks[i] = { counter = nil, pattern = nil }
+      tracks[i] = { counter = nil, pattern = nil }
     end
   end
   


### PR DESCRIPTION
Hi, how would such a [latch mode](https://llllllll.co/search?q=latch%20topic%3A45349) feel like to you? I am not familiar with stretta's original _press cafe_, nor do I know how faithful do you wish bistro to be to it's features.

The implementation is straightforward, but I think it works. It keeps the original idea that a pattern clears when one change from the patterns or lengths pages, although I personally feel it could stay latched, as this is kind of the idea of latching, and might be fun to change patterns on the go: another play modality, but also feature-creep.

I also fixed the engine parameters on <kbd>E2</kbd> and <kbd>E3</kbd> on the play page. Looks like they were tracking another engine (Polyperc?) but lost track of the current engine which is KarplusStrong from Awake-Rings.

Plus a little docs. Sorry so many disparate little things in one PR.